### PR TITLE
Hot fix/blacklisted types and layout adjustment

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -110,6 +110,7 @@ module.exports = {
     },
     {
       /**
+       * FIXME: Added temporary to Local Plugins while waiting for an official fix
        * This plugin generates fileNodes in your graphQL schema
        * and add File type to it. You can now use gatsby-plugin-sharp and gatsby-transformer-sharp
        * in your GraphQL schema.

--- a/gatsby/createProgramSessionPages.js
+++ b/gatsby/createProgramSessionPages.js
@@ -3,7 +3,21 @@ const moment = require(`moment`);
 const groupBy = require(`../src/utils/groupBy.js`);
 const slugify = require(`../src/utils/strings/slugify.js`);
 
-const blackListedTypes = ['activites', 'presentiel', 'intermission'];
+/**
+ * Session types allowed to be displaying
+ * Blacklisted for now:
+ *   - activites
+ *   - presentiel
+ *   - intermission
+ *   - reseautage
+ */
+const allowedTypes = [
+  'conference',
+  'atelier',
+  'qanda',
+  'contenu-sur-demande',
+  'pitch-ton-waq',
+];
 
 /**  This function queries Gatsby's GraphQL server and asks for
  * All Plannings from Swapcard. If there are any GraphQL error it throws an error
@@ -61,7 +75,7 @@ const createSession = async ({ plannings, actions, reporter, variables }) => {
   reporter.info('creating session pages:');
 
   plannings
-    .filter((planning) => !blackListedTypes.includes(planning.type))
+    .filter((planning) => allowedTypes.includes(planning.type))
     .map(async (planning) => {
       const { title, id } = planning;
 
@@ -120,7 +134,7 @@ const createProgram = async ({ plannings, actions, reporter, variables }) => {
     reporter.info(getPagePath(pageNumber));
 
     const planningIds = planningsGroupByDate[date]
-      .filter((current) => !blackListedTypes.includes(current.type))
+      .filter((current) => allowedTypes.includes(current.type))
       .map((current) => current.id);
 
     const pagePaths = array.map((_, i) => getPagePath(i + 1));

--- a/gatsby/createProgramSessionPages.js
+++ b/gatsby/createProgramSessionPages.js
@@ -168,7 +168,7 @@ module.exports = async ({ graphql, actions, reporter }) => {
   const variables = {
     eventId: `${process.env.SWAPCARD_EVENT_ID}`,
     page: 1,
-    pageSize: 100,
+    pageSize: 200,
   };
 
   reporter.info('start fetching data from Swapcard');

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "eslint-plugin-formatjs": "^2.15.0",
     "gatsby": "^3.5.0",
     "gatsby-image": "^3.5.0",
-    "gatsby-image-graphql-schema": "^1.1.1",
     "gatsby-plugin-facebook-pixel": "^1.0.7",
     "gatsby-plugin-google-tagmanager": "^3.5.0",
     "gatsby-plugin-graphql-loader": "^1.0.2",

--- a/plugins/gatsby-image-graphql-schema/gatsby-node.js
+++ b/plugins/gatsby-image-graphql-schema/gatsby-node.js
@@ -1,0 +1,92 @@
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable no-underscore-dangle */
+const { createRemoteFileNode } = require(`gatsby-source-filesystem`);
+
+/**
+ * Check if current fieldName is type or name member
+ * @param imageNames
+ * @param typeName
+ * @param fieldName
+ * @returns {*|boolean}
+ */
+const isTypeAndNameMember = (imageNames, typeName, fieldName) => {
+  return (
+    imageNames &&
+    !!imageNames.find((imageName) => {
+      const fieldParts = imageName.split('.');
+      if (
+        fieldParts.length > 1 &&
+        fieldParts[0] === typeName &&
+        fieldParts[1] === fieldName
+      ) {
+        return true;
+      }
+      if (fieldParts[0] === fieldName) {
+        return true;
+      }
+      return false;
+    })
+  );
+};
+
+exports.createResolvers = (
+  { actions, cache, createNodeId, createResolvers, store, reporter },
+  configOptions
+) => {
+  const { createNode } = actions;
+  const { imageNames, schemaTypeName, baseUrl } = configOptions;
+  if (!imageNames || !Array.isArray(imageNames)) {
+    throw new Error(
+      'No image names were given in gatsby image graphql plugin.'
+    );
+  }
+
+  const state = store.getState();
+  const schema = state.schemaCustomization.thirdPartySchemas.filter(
+    (schemaPart) => schemaPart._typeMap[schemaTypeName]
+  )[0];
+
+  if (!schema) {
+    throw new Error(`Schema: '${schemaTypeName} was not found.'`);
+  }
+
+  const typeMap = schema._typeMap;
+  const resolvers = {};
+
+  Object.keys(typeMap).forEach((typeName) => {
+    const typeEntry = typeMap[typeName];
+    const typeFields =
+      (typeEntry && typeEntry.getFields && typeEntry.getFields()) || {};
+    const typeResolver = {};
+    Object.keys(typeFields).forEach((fieldName) => {
+      if (isTypeAndNameMember(imageNames, typeName, fieldName)) {
+        typeResolver[`${fieldName}Sharp`] = {
+          type: 'File',
+          resolve(source) {
+            const url = baseUrl
+              ? baseUrl + source[fieldName]
+              : source[fieldName];
+
+            if (url) {
+              return createRemoteFileNode({
+                url,
+                store,
+                cache,
+                createNode,
+                createNodeId,
+                reporter,
+              });
+            }
+            return null;
+          },
+        };
+      }
+      if (Object.keys(typeResolver).length) {
+        resolvers[typeName] = typeResolver;
+      }
+    });
+    if (Object.keys(resolvers).length) {
+      createResolvers(resolvers);
+    }
+  });
+};

--- a/plugins/gatsby-image-graphql-schema/package.json
+++ b/plugins/gatsby-image-graphql-schema/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "gatsby-image-graphql-schema",
+  "version": "1.1.1",
+  "description": "Generate file nodes on images from GraphQL schema",
+  "main": "gatsby-node.js",
+  "scripts": {},
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AntoineBourin/gatsby-image-graphql-schema"
+  },
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "gatsby-image"
+  ],
+  "author": "Antoine Bourin",
+  "license": "ISC"
+}

--- a/src/components/ScheduleCardList/ScheduleCard/ScheduleCard.jsx
+++ b/src/components/ScheduleCardList/ScheduleCard/ScheduleCard.jsx
@@ -61,7 +61,7 @@ const ScheduleCard = ({
           <div
             css={`
               position: absolute;
-              top: 40px;
+              top: ${content ? '40px' : '20px'};
               left: -8px;
             `}
           >

--- a/src/components/SpeakerCard/SpeakerCard.jsx
+++ b/src/components/SpeakerCard/SpeakerCard.jsx
@@ -1,13 +1,12 @@
 // vendors
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useMedia } from 'react-use';
 
 // styles
 import {
   StyledSpeakerCard,
-  CardMobileHeader,
   SpeakerPicture,
-  SpeakerInfo,
   // SpeakerLinks,
   // SpeakerLinkItem,
   // LinkIcon,
@@ -15,9 +14,7 @@ import {
   HeaderInfo,
   SpeakerDescription,
 } from './SpeakerCard.styles';
-
-// components
-import Sidebar from '../LayoutSections/Sidebar';
+import { greaterThan, lessThanCondition } from '../../utils/mediaQuery';
 
 // images
 // import iconEmail from '../../images/socialMedia/email.svg';
@@ -29,6 +26,7 @@ import Sidebar from '../LayoutSections/Sidebar';
 
 const SpeakerCard = ({ speaker }) => {
   // const socialNetworksGroupByType = groupBy(speaker.socialNetworks, 'type');
+  const mobile = useMedia(lessThanCondition(768));
 
   const picture = speaker.photoUrlSharp?.childImageSharp?.fixed;
 
@@ -65,29 +63,45 @@ const SpeakerCard = ({ speaker }) => {
   const fullName = `${speaker.firstName} ${speaker.lastName}`;
 
   return (
-    <Sidebar css={StyledSpeakerCard} contentMin='75%' sideWidth='8ch'>
-      <div>
-        <CardMobileHeader>
-          <SpeakerPicture fixed={picture} alt={fullName} />
-          <div>
-            <SpeakerInfo>
-              <HeaderInfo>{fullName}</HeaderInfo>
-              <HeaderInfo>{speaker.jobTitle}</HeaderInfo>
-              <HeaderInfo>{speaker.organization}</HeaderInfo>
-            </SpeakerInfo>
+    <StyledSpeakerCard>
+      <div
+        css={`
+          display: grid;
+          grid-template-columns: auto 1fr;
 
-            {/* <SpeakerLinks>
-              {contactLinks.map((link) => (
-                <SpeakerLinkItem key={link.type}>
-                  <a href={link.url} rel='noopener noreferrer' target='_blank'>
-                    <LinkIcon src={link.icon} alt={link.name} />
-                  </a>
-                </SpeakerLinkItem>
-              ))}
-            </SpeakerLinks> */}
-          </div>
-        </CardMobileHeader>
-        <div>
+          grid-column-gap: ${speaker.photoUrl ? `var(--gap)` : undefined};
+          grid-row-gap: var(--gap);
+        `}
+      >
+        {speaker.photoUrl && (
+          <SpeakerPicture
+            fixed={picture}
+            alt={fullName}
+            css={`
+              grid-row: 1;
+              grid-column: 1;
+            `}
+          />
+        )}
+
+        {/* {contactLinks.length > 0 && (
+          <SpeakerLinks css={`grid-row: 2; grid-column: 1;`}>
+            {contactLinks.map((link) => (
+              <SpeakerLinkItem key={link.type}>
+                <a href={link.url} rel='noopener noreferrer' target='_blank'>
+                  <LinkIcon src={link.icon} alt={link.name} />
+                </a>
+              </SpeakerLinkItem>
+            ))}
+          </SpeakerLinks>
+        )} */}
+
+        <div
+          css={`
+            grid-row: 1;
+            grid-column: 2;
+          `}
+        >
           <SpeakerHeader>
             <HeaderInfo>{fullName}</HeaderInfo>
             {speaker.jobTitle && <HeaderInfo>{speaker.jobTitle}</HeaderInfo>}
@@ -95,12 +109,36 @@ const SpeakerCard = ({ speaker }) => {
               <HeaderInfo>{speaker.organization}</HeaderInfo>
             )}
           </SpeakerHeader>
-          <SpeakerDescription
-            dangerouslySetInnerHTML={{ __html: speaker.biography }}
-          />
+
+          {!mobile && speaker.biography && (
+            <SpeakerDescription
+              css={`
+                margin-top: 16px;
+              `}
+              dangerouslySetInnerHTML={{ __html: speaker.biography }}
+            />
+          )}
         </div>
+
+        {mobile && speaker.biography && (
+          <div
+            css={`
+              grid-row: 2;
+              grid-column: 1 / span 2;
+
+              ${greaterThan(768)} {
+                grid-row: 1;
+                grid-column: 2;
+              }
+            `}
+          >
+            <SpeakerDescription
+              dangerouslySetInnerHTML={{ __html: speaker.biography }}
+            />
+          </div>
+        )}
       </div>
-    </Sidebar>
+    </StyledSpeakerCard>
   );
 };
 
@@ -111,9 +149,9 @@ SpeakerCard.propTypes = {
   speaker: PropTypes.shape({
     firstName: PropTypes.string.isRequired,
     lastName: PropTypes.string.isRequired,
-    jobTitle: PropTypes.string.isRequired,
-    organization: PropTypes.string.isRequired,
-    biography: PropTypes.string.isRequired,
+    jobTitle: PropTypes.string,
+    organization: PropTypes.string,
+    biography: PropTypes.string,
     email: PropTypes.string,
     websiteUrl: PropTypes.string,
     photoUrl: PropTypes.string,

--- a/src/components/SpeakerCard/SpeakerCard.styles.js
+++ b/src/components/SpeakerCard/SpeakerCard.styles.js
@@ -1,5 +1,5 @@
 // vendors
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import Img from 'gatsby-image';
 
 // utils
@@ -11,27 +11,21 @@ import { fontWeights } from '../../styles/typography';
 import breakpoints from '../../styles/breakpoints';
 import breakpointsRange from '../../utils/breakpointsRange';
 
-export const StyledSpeakerCard = css`
+export const StyledSpeakerCard = styled.div`
   background-color: ${colors.gris20};
   border-radius: 8px;
 
   ${breakpointsRange(
-    [{ prop: 'padding', sizes: [12, 24], bases: [16, 20] }],
-    breakpoints.spacings
+    [
+      { prop: '--gap', sizes: [12, 24] },
+      { prop: 'padding', sizes: [12, 24] },
+    ],
+    breakpoints.spacings,
+    { bases: [16, 20] }
   )};
 `;
 
-export const CardMobileHeader = styled.div`
-  display: flex;
-
-  ${greaterThan(768)} {
-    display: block;
-  }
-`;
-
 export const SpeakerPicture = styled(Img)`
-  margin-right: 12px;
-
   border-radius: 6px;
 
   ${greaterThan(768)} {
@@ -45,16 +39,6 @@ export const SpeakerPicture = styled(Img)`
     ],
     breakpoints.spacings
   )};
-`;
-
-export const SpeakerInfo = styled.div`
-  display: block;
-
-  color: ${colors.bleu80};
-
-  ${greaterThan(768)} {
-    display: none;
-  }
 `;
 
 export const SpeakerLinks = styled.ul`
@@ -101,22 +85,34 @@ export const LinkIcon = styled.img`
 `;
 
 export const SpeakerHeader = styled.p`
-  display: none;
-
-  margin-top: 0;
+  margin: 0;
 
   color: ${colors.bleu80};
-
-  ${greaterThan(768)} {
-    display: block;
-  }
 `;
 
 export const HeaderInfo = styled.span`
   display: block;
 
+  font-weight: ${fontWeights.regular};
+
+  ${breakpointsRange(
+    [
+      { prop: 'fontSize', sizes: [14, 16], bases: [16, 20] },
+      { prop: 'lineHeight', sizes: [16, 22], bases: [14, 16], unit: '' },
+    ],
+    breakpoints.spacings
+  )};
+
   :first-child {
     font-weight: ${fontWeights.bold};
+
+    ${breakpointsRange(
+      [
+        { prop: 'fontSize', sizes: [16, 16], bases: [16, 20] },
+        { prop: 'lineHeight', sizes: [20, 22], bases: [16, 16], unit: '' },
+      ],
+      breakpoints.spacings
+    )};
   }
 
   ${greaterThan(768)} {
@@ -130,6 +126,8 @@ export const HeaderInfo = styled.span`
 
       color: ${colors.gris40};
 
+      font-weight: ${fontWeights.regular};
+
       content: '|';
     }
 
@@ -139,17 +137,11 @@ export const HeaderInfo = styled.span`
       }
     }
   }
-
-  ${breakpointsRange(
-    [
-      { prop: 'fontSize', sizes: [16, 16], bases: [16, 20] },
-      { prop: 'lineHeight', sizes: [20, 22], bases: [16, 16], unit: '' },
-    ],
-    breakpoints.spacings
-  )};
 `;
 
-export const SpeakerDescription = styled.div`
+export const SpeakerDescription = styled.p`
+  margin: 0;
+
   color: ${colors.gris90};
 
   ${breakpointsRange(

--- a/src/components/SpeakerCard/SpeakerCard.styles.js
+++ b/src/components/SpeakerCard/SpeakerCard.styles.js
@@ -139,7 +139,7 @@ export const HeaderInfo = styled.span`
   }
 `;
 
-export const SpeakerDescription = styled.p`
+export const SpeakerDescription = styled.div`
   margin: 0;
 
   color: ${colors.gris90};

--- a/src/components/Tag/Tag.jsx
+++ b/src/components/Tag/Tag.jsx
@@ -45,9 +45,7 @@ const Tag = ({ category, speaker, eventType, place, outlined, children }) => {
   const eventTypes = {
     conference: 'Conférence',
     atelier: 'Atelier',
-    reseautage: 'Réseautage',
     qanda: 'Q&A',
-    keynote: 'Keynote',
     'contenu-sur-demande': 'Contenu sur demande',
     'pitch-ton-waq': 'Pitch ton WAQ',
   };
@@ -132,9 +130,7 @@ Tag.propTypes = {
   eventType: PropTypes.oneOf([
     'conference',
     'atelier',
-    'reseautage',
     'qanda',
-    'keynote',
     'contenu-sur-demande',
     'pitch-ton-waq',
   ]),

--- a/src/templates/Program/Session/Session.jsx
+++ b/src/templates/Program/Session/Session.jsx
@@ -75,8 +75,9 @@ const EventContainer = styled.div`
   )};
 `;
 
-const EventTitle = styled.h1`
+const EventTitle = styled.h2`
   margin-top: 0;
+  margin-bottom: 16px;
 
   color: ${colors.bleu80};
 
@@ -221,9 +222,12 @@ const Session = ({ data, pageContext: { pageNumber, isLastPage } }) => {
 
                 <div>
                   <EventTitle>{title}</EventTitle>
-                  <EventDescription
-                    dangerouslySetInnerHTML={{ __html: htmlDescription }}
-                  />
+
+                  {htmlDescription && (
+                    <EventDescription
+                      dangerouslySetInnerHTML={{ __html: htmlDescription }}
+                    />
+                  )}
                 </div>
 
                 {(categories.length > 0 || type || place) && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -6969,11 +6969,6 @@ gatsby-graphiql-explorer@^1.5.0:
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-gatsby-image-graphql-schema@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/gatsby-image-graphql-schema/-/gatsby-image-graphql-schema-1.1.1.tgz#458fb7ec4471c5b22b7f4e2566670a0e9f882873"
-  integrity sha512-mTsU1K+n2Ak1P5AvcMSMVkg6GAc8zHuEZDzLyuqPQ4f++65wL20ApQbYVtOjqdSRi0uLwwnXbvsP0eeEZUOsPg==
-
 gatsby-image@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/gatsby-image/-/gatsby-image-3.5.0.tgz#fe76d1d5638bdbe1255c2226a1b00539887af798"


### PR DESCRIPTION
Dans cette PR :
- Ne pas afficher en tout temps les sessions de types `presentiel` et `intermission` en tout temps.
- Ne pas afficher les session de type `activites` **jusqu'au 9 juin**.
- Ajustement du layout des composants **ScheduleCard** et **SpeakerCard** pour afficher uniquement les données disponibles provenant de Swapcard.

UPDATE
- Afficher également les sessions de type `presentiel` uniquement **à partir du 9 juin**.
- Ne pas afficher les sessions de types `reseautage` et `keynote` (non utilisé)
- Augmenter la limite du nombre de résultats retourné par Swapcard à 200