### PR TITLE
:bug: fix: Force clean cache before new build

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "lint:style": "npx stylelint \"**/*.{css,jsx,js}\"",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "build:noindex": "npm run build && echo '/*\n\tX-Robots-Tag: noindex' >> public/_headers",
-    "build": "gatsby build",
+    "build": "gatsby clean && gatsby build",
     "develop": "gatsby develop",
     "start": "gatsby develop",
     "serve": "gatsby serve",


### PR DESCRIPTION
### CORRECTIFS 🐛
- Forcer un clean de la cache de Gatsby avant chaque nouveau build afin d'éviter tout erreur potentielle de build sur Netlify